### PR TITLE
Removed "http" protocol from dsq.src

### DIFF
--- a/pi.disqus.php
+++ b/pi.disqus.php
@@ -22,7 +22,7 @@ class Plugin_disqus extends Plugin {
             /* * * DON\'T EDIT BELOW THIS LINE * * */
             (function() {
                 var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
-                dsq.src = "http://" + disqus_shortname + ".disqus.com/embed.js";
+                dsq.src = "//" + disqus_shortname + ".disqus.com/embed.js";
                 (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
             })();
         </script>


### PR DESCRIPTION
The latest Disqus documentation suggest leaving `http:` out of `dsq.src` to account for serving pages over SSL.
